### PR TITLE
Clean up skript theme CSS

### DIFF
--- a/css/themes/skript-theme.css
+++ b/css/themes/skript-theme.css
@@ -1,31 +1,6 @@
 /* Skript Theme - Blautöne */
 
 /* Header-Anpassung für Skript-Tab */
-#nav-skript.active,
-header nav ul li a#nav-skript:hover {
-    border-bottom: 2px solid #4a90e2; /* Blauton */
-    color: #4a90e2; /* Optional: Textfarbe ändern bei Aktiv/Hover */
-}
-
-/* Allgemeine Elemente im Skript-Bereich */
-.skript-page h1, .skript-page h2 {
-    color: #2a67a2; /* Dunklerer Blauton für Überschriften */
-}
-
-.skript-page a:hover {
-    color: #357ABD;
-}
-
-/* Beispiel für ein interaktives Element im Skript-Theme */
-.interactive-box-skript {
-    background-color: #e9f2fa;
-    border-left: 5px solid #4a90e2;
-    padding: 15px;
-    margin: 20px 0;
-}
-/* Skript Theme - Blautöne */
-
-/* Header-Anpassung für Skript-Tab */
 .skript-page header nav ul li a#nav-skript.active,
 .skript-page header nav ul li a#nav-skript:hover {
     border-bottom: 3px solid var(--skript-accent-color); /* Etwas dickerer Border */


### PR DESCRIPTION
## Summary
- remove duplicated static color definitions from `skript-theme.css`
- keep only variable-based rules for the Skript section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f65c1c3e4832e8a7b2ed0a23255b1