### PR TITLE
Add quiz feature skeleton

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -321,3 +321,7 @@ footer ul li a:hover {
        gap: 20px;
    }
 */
+/* Quiz-Komponenten */
+.quiz-question { margin-bottom: 1em; }
+.quiz-result { margin-top: 1em; font-weight: bold; }
+

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,0 +1,52 @@
+// js/quiz.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    const quizContainer = document.getElementById('quiz-container');
+    const dataScript = document.getElementById('quiz-data');
+
+    if (!quizContainer || !dataScript) {
+        return;
+    }
+
+    let quizData;
+    try {
+        quizData = JSON.parse(dataScript.textContent);
+    } catch (e) {
+        console.error('Quiz data is not valid JSON');
+        return;
+    }
+
+    function renderQuiz() {
+        const htmlParts = [];
+        quizData.questions.forEach((q, qi) => {
+            htmlParts.push(`<div class="quiz-question">`);
+            htmlParts.push(`<p>${q.question}</p>`);
+            q.options.forEach((opt, oi) => {
+                const id = `q${qi}_o${oi}`;
+                htmlParts.push(
+                    `<label for="${id}"><input type="radio" id="${id}" name="q${qi}" value="${oi}"> ${opt}</label>`
+                );
+            });
+            htmlParts.push('</div>');
+        });
+        htmlParts.push('<button id="quiz-submit">Antworten prüfen</button>');
+        htmlParts.push('<div id="quiz-result" class="quiz-result"></div>');
+        quizContainer.innerHTML = htmlParts.join('');
+    }
+
+    function evaluateQuiz() {
+        let score = 0;
+        quizData.questions.forEach((q, qi) => {
+            const selected = quizContainer.querySelector(`input[name="q${qi}"]:checked`);
+            if (selected && parseInt(selected.value, 10) === q.correct) {
+                score++;
+            }
+        });
+        const result = `${score} / ${quizData.questions.length} korrekt`;
+        document.getElementById('quiz-result').textContent = result;
+    }
+
+    renderQuiz();
+    const submitBtn = document.getElementById('quiz-submit');
+    submitBtn.addEventListener('click', evaluateQuiz);
+});

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,8 @@ Die Website ist in mehrere Hauptbereiche unterteilt:
     - Der Header und Footer wird extern gespeichert und am Ende über main.js geladen
 -   **JavaScript:**
     -   `js/main.js`: Für allgemeine, seitenübergreifende Skripte.
-    -   Spezifische JS-Dateien im `js/`-Ordner (z.B. `quiz-script.js`, `interactive-element1.js`) sind für einzelne interaktive Elemente oder Funktionen gedacht. Diese sollten bei Bedarf in den entsprechenden HTML-Seiten eingebunden werden.
+    -   `js/quiz.js`: Grundlegende Funktionen für einfache Multiple-Choice-Quizze.
+    -   Spezifische JS-Dateien im `js/`-Ordner (z.B. `interactive-element1.js`) sind für einzelne interaktive Elemente oder Funktionen gedacht. Diese sollten bei Bedarf in den entsprechenden HTML-Seiten eingebunden werden.
 
 ## Eine neue HTML-Seite erstellen (Anleitung für ein LLM oder menschliche Bearbeiter)
 

--- a/skript/thema1.html
+++ b/skript/thema1.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kurstitel - Skript: Thema 1</title>
+    <link rel="stylesheet" href="../css/normalize.css">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/themes/skript-theme.css">
+</head>
+<body class="skript-page">
+    <header></header>
+
+    <main>
+        <div class="container">
+            <h1>Thema 1: Grundlagen der Kinematik</h1>
+            <p>Hier folgt der Inhalt des Themas ...</p>
+
+            <section id="quiz-section">
+                <h2>Quiz</h2>
+                <div id="quiz-container"></div>
+                <script type="application/json" id="quiz-data">
+                {
+                    "questions": [
+                        {
+                            "question": "Welche Größe beschreibt die Geschwindigkeit?",
+                            "options": ["Weg pro Zeit", "Kraft mal Zeit", "Masse mal Beschleunigung"],
+                            "correct": 0
+                        },
+                        {
+                            "question": "Welche Einheit hat die Beschleunigung?",
+                            "options": ["m/s", "m/s²", "N"],
+                            "correct": 1
+                        }
+                    ]
+                }
+                </script>
+            </section>
+        </div>
+    </main>
+
+    <footer></footer>
+    <script src="../js/main.js"></script>
+    <script src="../js/quiz.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add JS to render simple multiple choice quizzes
- style quiz elements
- provide example topic page `skript/thema1.html` with a quiz
- document new `quiz.js` script in README

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683f65a768e0832e84206b8ce1555060